### PR TITLE
fix inconsitent casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 # The maintainers of electrs are not deeply familiar with Docker, so you should DYOR.
 # If you are not familiar with Docker either it's probably be safer to NOT use it.
 
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 RUN apt-get update -qqy
 RUN apt-get install -qqy librocksdb-dev curl
 
 ### Electrum Rust Server ###
-FROM base as electrs-build
+FROM base AS electrs-build
 RUN apt-get install -qqy cargo clang cmake
 
 # Install electrs
@@ -17,7 +17,7 @@ ENV ROCKSDB_INCLUDE_DIR=/usr/include
 ENV ROCKSDB_LIB_DIR=/usr/lib
 RUN cargo install --locked --path .
 
-FROM base as result
+FROM base AS result
 # Copy the binaries
 COPY --from=electrs-build /root/.cargo/bin/electrs /usr/bin/electrs
 


### PR DESCRIPTION
Switch from lower case "as" to upper case "AS" to be consistent with the other keywords.